### PR TITLE
Allow group privileges to be filtered.

### DIFF
--- a/src/iplant_groups/clients/grouper.clj
+++ b/src/iplant_groups/clients/grouper.clj
@@ -484,32 +484,35 @@
 
 ;; This is only available as a Lite request; ActAsSubject works differently.
 (defn- format-group-folder-privileges-lookup-request
-  [entity-type username group-or-folder-name]
-  (if-let [name-key (get {:group :groupName
+  [entity-type username group-or-folder-name params]
+  (if-let [name-key (get {:group  :groupName
                           :folder :stemName}
                          entity-type)]
     {:WsRestGetGrouperPrivilegesLiteRequest
-     {:actAsSubjectId username
-      :includeSubjectDetail "T"
-      :includeGroupDetail   "T"
-      name-key group-or-folder-name}}
+     (remove-vals nil? {:actAsSubjectId       username
+                        :includeSubjectDetail "T"
+                        :includeGroupDetail   "T"
+                        name-key              group-or-folder-name
+                        :subjectId            (:subject-id params)
+                        :subjectSourceId      (:subject-source-id params)
+                        :privilegeName        (:privilege params)})}
     (throw+ {:type :clojure-commons.exception/bad-request :entity-type entity-type})))
 
 (defn- get-group-folder-privileges
-  [entity-type username group-or-folder-name]
+  [entity-type username name params]
   (with-trap [default-error-handler]
-    (let [response (-> (format-group-folder-privileges-lookup-request entity-type username group-or-folder-name)
+    (let [response (-> (format-group-folder-privileges-lookup-request entity-type username name params)
                        (grouper-post "grouperPrivileges")
                        :WsGetGrouperPrivilegesLiteResult)]
-      [(:privilegeResults response) (:subjectAttributeNames response)])))
+      (log/spy :warn [(:privilegeResults response) (:subjectAttributeNames response)]))))
 
 (defn get-group-privileges
-  [username group-name]
-  (get-group-folder-privileges :group username group-name))
+  [username group-name & [params]]
+  (get-group-folder-privileges :group username group-name params))
 
 (defn get-folder-privileges
-  [username folder-name]
-  (get-group-folder-privileges :folder username folder-name))
+  [username folder-name & [params]]
+  (get-group-folder-privileges :folder username folder-name params))
 
 ;; Add/remove group/folder privileges
 

--- a/src/iplant_groups/clients/grouper.clj
+++ b/src/iplant_groups/clients/grouper.clj
@@ -504,7 +504,7 @@
     (let [response (-> (format-group-folder-privileges-lookup-request entity-type username name params)
                        (grouper-post "grouperPrivileges")
                        :WsGetGrouperPrivilegesLiteResult)]
-      (log/spy :warn [(:privilegeResults response) (:subjectAttributeNames response)]))))
+      [(:privilegeResults response) (:subjectAttributeNames response)])))
 
 (defn get-group-privileges
   [username group-name & [params]]

--- a/src/iplant_groups/clients/grouper.clj
+++ b/src/iplant_groups/clients/grouper.clj
@@ -498,13 +498,20 @@
                         :privilegeName        (:privilege params)})}
     (throw+ {:type :clojure-commons.exception/bad-request :entity-type entity-type})))
 
+(defn- filter-privileges
+  [privileges {:keys [subject-source-id]}]
+  (if subject-source-id
+    (filter (fn [priv] (= (:sourceId (:wsSubject priv)) subject-source-id)) privileges)
+    privileges))
+
 (defn- get-group-folder-privileges
   [entity-type username name params]
   (with-trap [default-error-handler]
     (let [response (-> (format-group-folder-privileges-lookup-request entity-type username name params)
                        (grouper-post "grouperPrivileges")
                        :WsGetGrouperPrivilegesLiteResult)]
-      [(:privilegeResults response) (:subjectAttributeNames response)])))
+      [(filter-privileges (:privilegeResults response) params)
+       (:subjectAttributeNames response)])))
 
 (defn get-group-privileges
   [username group-name & [params]]

--- a/src/iplant_groups/routes/groups.clj
+++ b/src/iplant_groups/routes/groups.clj
@@ -63,7 +63,7 @@
 
     (context "/privileges" []
       (GET "/" []
-        :query       [params StandardUserQueryParams]
+        :query       [params GroupPrivilegeSearchQueryParams]
         :return      GroupPrivileges
         :summary     "List Group Privileges"
         :description "This endpoint allows callers to list the privileges visible to the current user of a single

--- a/src/iplant_groups/routes/schemas/privileges.clj
+++ b/src/iplant_groups/routes/schemas/privileges.clj
@@ -1,5 +1,5 @@
 (ns iplant_groups.routes.schemas.privileges
-  (:use [common-swagger-api.schema :only [describe]])
+  (:use [common-swagger-api.schema :only [describe StandardUserQueryParams NonBlankString]])
   (:require [iplant_groups.routes.schemas.subject :as subject]
             [iplant_groups.routes.schemas.group :as group]
             [iplant_groups.routes.schemas.folder :as folder]
@@ -7,6 +7,17 @@
 
 (def ValidFolderPrivileges (s/enum "create" "stem" "stemAttrRead" "stemAttrUpdate"))
 (def ValidGroupPrivileges (s/enum "view" "read" "update" "admin" "optin" "optout" "groupAttrRead" "groupAttrUpdate"))
+
+(s/defschema GroupPrivilegeSearchQueryParams
+  (assoc StandardUserQueryParams
+    (s/optional-key :privilege)
+    (describe ValidGroupPrivileges "The privilege name to search for.")
+
+    (s/optional-key :subject-id)
+    (describe NonBlankString "The subject ID to search for.")
+
+    (s/optional-key :subject-source-id)
+    (describe NonBlankString "The subject source ID to search for.")))
 
 (s/defschema GroupPrivilegeUpdate
   {:subject_id (describe String "The subject ID.")

--- a/src/iplant_groups/service/folders.clj
+++ b/src/iplant_groups/service/folders.clj
@@ -26,12 +26,12 @@
 (defn add-folder-privilege
   [folder-name subject-id privilege-name {:keys [user]}]
   (let [[privilege attribute-names] (grouper/add-folder-privileges user folder-name [subject-id] [privilege-name])]
-    (fmt/format-privilege attribute-names privilege :wsSubject)))
+    (fmt/format-privilege attribute-names privilege)))
 
 (defn remove-folder-privilege
   [folder-name subject-id privilege-name {:keys [user]}]
   (let [[privilege attribute-names] (grouper/remove-folder-privileges user folder-name [subject-id] [privilege-name])]
-    (fmt/format-privilege attribute-names privilege :wsSubject)))
+    (fmt/format-privilege attribute-names privilege)))
 
 (defn update-folder-privileges
   [folder-name {:keys [updates]} {:keys [user] :as params}]

--- a/src/iplant_groups/service/format.clj
+++ b/src/iplant_groups/service/format.clj
@@ -117,7 +117,7 @@
          :subject   (format-subject attribute-names (subject-key privilege))}
         (remove-vals nil?)))
   ([attribute-names privilege]
-   (format-privilege attribute-names privilege :ownerSubject)))
+   (format-privilege attribute-names privilege :wsSubject)))
 
 (defn format-attribute-name
   [attribute-name]

--- a/src/iplant_groups/service/groups.clj
+++ b/src/iplant_groups/service/groups.clj
@@ -48,12 +48,12 @@
 (defn add-group-privilege
   [group-name subject-id privilege-name {:keys [user]}]
   (let [[privilege attribute-names] (grouper/add-group-privileges user group-name [subject-id] [privilege-name])]
-    (fmt/format-privilege attribute-names privilege :wsSubject)))
+    (fmt/format-privilege attribute-names privilege)))
 
 (defn remove-group-privilege
   [group-name subject-id privilege-name {:keys [user]}]
   (let [[privilege attribute-names] (grouper/remove-group-privileges user group-name [subject-id] [privilege-name])]
-    (fmt/format-privilege attribute-names privilege :wsSubject)))
+    (fmt/format-privilege attribute-names privilege)))
 
 (defn update-group
   [group-name {:keys [name description display_extension]} {:keys [user]}]

--- a/src/iplant_groups/service/groups.clj
+++ b/src/iplant_groups/service/groups.clj
@@ -24,8 +24,8 @@
     {:members (mapv #(fmt/format-subject attribute-names %) subjects)}))
 
 (defn get-group-privileges
-  [group-name {:keys [user]}]
-  (let [[privileges attribute-names] (grouper/get-group-privileges user group-name)]
+  [group-name {:keys [user] :as params}]
+  (let [[privileges attribute-names] (grouper/get-group-privileges user group-name params)]
     {:privileges (mapv #(fmt/format-privilege attribute-names %) privileges)}))
 
 (defn add-group


### PR DESCRIPTION
We've added the subject ID (`subject-id`), subject source ID (`subject-source-id`), and privilege name (`privilege`) to the criteria that can be used when filtering group privileges.