### PR TITLE
CORE-4: Changes to help Swaggerize terrain

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [org.cyverse/clojure-commons "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.9.1"]
+                 [org.cyverse/common-swagger-api "2.9.2-SNAPSHOT"]
                  [org.cyverse/event-messages "0.0.1"]
                  [org.cyverse/service-logging "2.8.0"]
                  [com.novemberain/langohr "3.5.1"]

--- a/src/iplant_groups/routes/schemas/privileges.clj
+++ b/src/iplant_groups/routes/schemas/privileges.clj
@@ -1,12 +1,13 @@
 (ns iplant-groups.routes.schemas.privileges
   (:use [common-swagger-api.schema :only [describe StandardUserQueryParams NonBlankString]])
-  (:require [common-swagger-api.schema.subjects :as subjects]
+  (:require [common-swagger-api.schema.groups :as group-schema]
+            [common-swagger-api.schema.subjects :as subjects]
             [iplant-groups.routes.schemas.group :as group]
             [iplant-groups.routes.schemas.folder :as folder]
             [schema.core :as s]))
 
 (def ValidFolderPrivileges (s/enum "create" "stem" "stemAttrRead" "stemAttrUpdate"))
-(def ValidGroupPrivileges (s/enum "view" "read" "update" "admin" "optin" "optout" "groupAttrRead" "groupAttrUpdate"))
+(def ValidGroupPrivileges group-schema/ValidGroupPrivileges)
 (def PrivilegeInheritanceLevel (s/enum "immediate" "inherited"))
 
 (s/defschema GroupPrivilegeSearchQueryParams

--- a/src/iplant_groups/routes/schemas/privileges.clj
+++ b/src/iplant_groups/routes/schemas/privileges.clj
@@ -45,21 +45,7 @@
 (s/defschema FolderPrivilegeUpdates
   {:updates (describe [FolderPrivilegeUpdate] "The privilege updates to process.")})
 
-(s/defschema Privilege
-  {:type
-   (describe String "The general type of privilege.")
-
-   :name
-   (describe String "The privilege name, under the type")
-
-   (s/optional-key :allowed)
-   (describe Boolean "Whether the privilege is marked allowed.")
-
-   (s/optional-key :revokable)
-   (describe Boolean "Whether the privilege is marked revokable.")
-
-   :subject
-   (describe subjects/Subject "The subject/user with the privilege.")})
+(def Privilege group-schema/Privilege)
 
 (s/defschema GroupPrivilege
   (assoc Privilege

--- a/src/iplant_groups/routes/schemas/privileges.clj
+++ b/src/iplant_groups/routes/schemas/privileges.clj
@@ -24,19 +24,10 @@
     (s/optional-key :inheritance-level)
     (describe PrivilegeInheritanceLevel "Allows the results to be filtered by inheritance level.")))
 
-(s/defschema GroupPrivilegeUpdate
-  {:subject_id (describe String "The subject ID.")
-   :privileges (describe [ValidGroupPrivileges] "The group privileges to assign.")})
-
-(s/defschema GroupPrivilegeUpdates
-  {:updates (describe [GroupPrivilegeUpdate] "The privilege updates to process.")})
-
-(s/defschema GroupPrivilegeRemoval
-  {:subject_id (describe String "The subject ID.")
-   :privileges (describe [ValidGroupPrivileges] "The group privileges to remove.")})
-
-(s/defschema GroupPrivilegeRemovals
-  {:updates (describe [GroupPrivilegeRemoval] "The privilege updates to process.")})
+(def GroupPrivilegeUpdate group-schema/GroupPrivilegeUpdate)
+(def GroupPrivilegeUpdates group-schema/GroupPrivilegeUpdates)
+(def GroupPrivilegeRemoval group-schema/GroupPrivilegeRemoval)
+(def GroupPrivilegeRemovals group-schema/GroupPrivilegeRemovals)
 
 (s/defschema FolderPrivilegeUpdate
   {:subject_id (describe String "The subject ID.")

--- a/src/iplant_groups/routes/schemas/privileges.clj
+++ b/src/iplant_groups/routes/schemas/privileges.clj
@@ -9,20 +9,33 @@
 (def ValidFolderPrivileges (s/enum "create" "stem" "stemAttrRead" "stemAttrUpdate"))
 (def ValidGroupPrivileges group-schema/ValidGroupPrivileges)
 (def PrivilegeInheritanceLevel (s/enum "immediate" "inherited"))
+(def ValidEntityTypes (s/enum "group" "folder"))
+
+(s/defschema PrivilegeSearchQueryParams
+  (assoc StandardUserQueryParams
+    (s/optional-key :inheritance-level)
+    (describe PrivilegeInheritanceLevel "Allows the results to be filtered by inheritance level")))
 
 (s/defschema GroupPrivilegeSearchQueryParams
-  (assoc StandardUserQueryParams
+  (assoc PrivilegeSearchQueryParams
     (s/optional-key :privilege)
-    (describe ValidGroupPrivileges "The privilege name to search for.")
+    (describe ValidGroupPrivileges "The privilege name to search for")
 
     (s/optional-key :subject-id)
-    (describe NonBlankString "The subject ID to search for.")
+    (describe NonBlankString "The subject ID to search for")
 
     (s/optional-key :subject-source-id)
-    (describe NonBlankString "The subject source ID to search for.")
+    (describe NonBlankString "The subject source ID to search for")))
 
-    (s/optional-key :inheritance-level)
-    (describe PrivilegeInheritanceLevel "Allows the results to be filtered by inheritance level.")))
+(s/defschema SubjectPrivilegeSearchQueryParams
+  (assoc PrivilegeSearchQueryParams
+    (s/optional-key :entity-type)
+    (describe ValidEntityTypes (str "If the entity type is provided, only privileges for the selected entity type "
+                                    "will be listed"))
+
+    (s/optional-key :folder)
+    (describe NonBlankString (str "If the folder name is provided, only privileges for entities underneath the "
+                                  "folder will be listed"))))
 
 (def GroupPrivilegeUpdate group-schema/GroupPrivilegeUpdate)
 (def GroupPrivilegeUpdates group-schema/GroupPrivilegeUpdates)
@@ -30,24 +43,35 @@
 (def GroupPrivilegeRemovals group-schema/GroupPrivilegeRemovals)
 
 (s/defschema FolderPrivilegeUpdate
-  {:subject_id (describe String "The subject ID.")
-   :privileges (describe [ValidFolderPrivileges] "The folder privileges to assign.")})
+  {:subject_id (describe String "The subject ID")
+   :privileges (describe [ValidFolderPrivileges] "The folder privileges to assign")})
 
 (s/defschema FolderPrivilegeUpdates
-  {:updates (describe [FolderPrivilegeUpdate] "The privilege updates to process.")})
+  {:updates (describe [FolderPrivilegeUpdate] "The privilege updates to process")})
 
-(def Privilege group-schema/Privilege)
+(def BasePrivilege group-schema/Privilege)
 
 (s/defschema GroupPrivilege
-  (assoc Privilege
-         :group (describe group/Group "The group the permission applies to.")))
+  (assoc BasePrivilege
+    :group (describe group/Group "The group the permission applies to")))
 
 (s/defschema FolderPrivilege
-  (assoc Privilege
-         :folder (describe folder/Folder "The folder the permission applies to.")))
+  (assoc BasePrivilege
+    :folder (describe folder/Folder "The folder the permission applies to")))
 
 (s/defschema GroupPrivileges
   {:privileges (describe [GroupPrivilege] "A list of group-centric privileges")})
 
 (s/defschema FolderPrivileges
   {:privileges (describe [FolderPrivilege] "A list of folder-centric privileges")})
+
+(s/defschema Privilege
+  (assoc BasePrivilege
+    (s/optional-key :group)
+    (describe group/Group "The group the permission applies to")
+
+    (s/optional-key :folder)
+    (describe folder/Folder "The folder the permission applies to")))
+
+(s/defschema Privileges
+  {:privileges (describe [Privilege] "The list of privileges")})

--- a/src/iplant_groups/routes/subjects.clj
+++ b/src/iplant_groups/routes/subjects.clj
@@ -3,6 +3,7 @@
         [common-swagger-api.schema.subjects]
         [iplant-groups.routes.schemas.group]
         [iplant-groups.routes.schemas.params]
+        [iplant-groups.routes.schemas.privileges]
         [ring.util.http-response :only [ok]])
   (:require [iplant-groups.service.subjects :as subjects]))
 
@@ -23,18 +24,26 @@
     Note: the response body will only contain the users that are found in the subject store."
     (ok (subjects/lookup params body)))
 
-  (GET "/:subject-id" []
+  (context "/:subject-id" []
     :path-params [subject-id :- SubjectIdPathParam]
-    :query       [params StandardUserQueryParams]
-    :return      Subject
-    :summary     "Get Subject Information"
-    :description "This endpoint allows callers to get information about a single subject."
-    (ok (subjects/get-subject subject-id params)))
 
-  (GET "/:subject-id/groups" []
-    :path-params [subject-id :- SubjectIdPathParam]
-    :query       [params GroupsForSubjectParams]
-    :return      GroupList
-    :summary     "List Groups for a Subject"
-    :description "This endpoint allows callers to list all groups that a subject belongs to."
-    (ok (subjects/groups-for-subject subject-id params))))
+    (GET "/" []
+      :query       [params StandardUserQueryParams]
+      :return      Subject
+      :summary     "Get Subject Information"
+      :description "This endpoint allows callers to get information about a single subject."
+      (ok (subjects/get-subject subject-id params)))
+
+    (GET "/groups" []
+      :query       [params GroupsForSubjectParams]
+      :return      GroupList
+      :summary     "List Groups for a Subject"
+      :description "This endpoint allows callers to list all groups that a subject belongs to."
+      (ok (subjects/groups-for-subject subject-id params)))
+
+    (GET "/privileges" []
+      :query       [params SubjectPrivilegeSearchQueryParams]
+      :return      Privileges
+      :summary     "List Subject Privileges"
+      :description "This endpoint allows callers to list all of the privileges granted to a subject."
+      (ok (subjects/privileges-for-subject subject-id params)))))

--- a/src/iplant_groups/service/subjects.clj
+++ b/src/iplant_groups/service/subjects.clj
@@ -23,3 +23,8 @@
                  (grouper/groups-for-subject-folder user subject-id folder)
                  (grouper/groups-for-subject user subject-id))]
     {:groups (mapv fmt/format-group result)}))
+
+(defn privileges-for-subject
+  [subject-id {:keys [user] :as params}]
+  (let [[privileges attribute-names] (grouper/get-subject-privileges user subject-id params)]
+    {:privileges (mapv #(fmt/format-privilege attribute-names %) privileges)}))


### PR DESCRIPTION
This PR contains two major changes:

- some schema definitions for privileges have been moved to common-swagger-api
- a new endpoint has been added to list privileges granted to a subject
