### PR TITLE
Enqueue group propagation messages

### DIFF
--- a/src/iplant_groups/amqp.clj
+++ b/src/iplant_groups/amqp.clj
@@ -5,7 +5,11 @@
             [langohr.channel :as lch]
             [langohr.queue :as lq]
             [langohr.consumers :as lc]
-            [langohr.exchange :as le]))
+            [langohr.exchange :as le]
+            [langohr.basic :as lb]
+            [service-logging.thread-context :as tc]
+            [slingshot.slingshot :refer [try+]]
+            [cheshire.core :as cheshire]))
 
 (defn- declare-queue
   [channel {exchange-name :name} queue-cfg topics]
@@ -31,3 +35,26 @@
     (declare-exchange channel exchange-cfg)
     (declare-queue channel exchange-cfg queue-cfg (keys handlers))
     (lc/blocking-subscribe channel (:name queue-cfg) (partial message-router handlers))))
+
+(defn publish-msg
+  [routing-key msg]
+  (try+
+    (let [timeNow (new java.util.Date)
+          connection (rmq/connect {:uri (config/amqp-uri)})
+          channel (lch/open connection)]
+      (tc/with-logging-context
+        {:amqp-routing-key routing-key
+         :amqp-message msg}
+        (log/info (format "Publishing AMQP message. routing-key=%s" routing-key)))
+      (lb/publish channel
+                  (config/exchange-name)
+                  routing-key
+                  (cheshire/encode {:message      msg
+                                    :timestamp_ms (.getTime timeNow)})
+                  {:content-type "application/json"
+                   :timestamp    timeNow})
+
+      (lch/close channel)
+      (rmq/close connection))
+    (catch Object _
+      (log/error (:throwable &throw-context) "Failed to publish message" (cheshire/encode msg)))))


### PR DESCRIPTION
(when doing operations on groups that have an ID handy to use)

I didn't add this stuff for the add/remove members endpoints just yet, because right now those don't get a hold of the group ID that we use for the messages. This should catch the biggest cases, I think, particularly ensuring that groups are propagated quickly when new groups are created.